### PR TITLE
Hide mobile footer on mobile devices

### DIFF
--- a/src/main/resources/pages/changepw.html
+++ b/src/main/resources/pages/changepw.html
@@ -83,6 +83,7 @@
                         </div>
                         <div id="goodresult"></div>
                         <div id="badresult"></div>
+                        
                     </div>
                 </form>
             </div>

--- a/src/main/resources/pages/forgotpw.html
+++ b/src/main/resources/pages/forgotpw.html
@@ -101,7 +101,8 @@
                 container.innerHTML = content;
             }
             
-            
+    
+    
     function submitValue(username) {
         console.log(username);
         var json = JSON.stringify({username : username});
@@ -144,6 +145,7 @@
             $('#username').focus();
             return false;
         }
+        
         if(username != '') {
             submitValue(username);
         }

--- a/src/main/resources/static/css/changepass.css
+++ b/src/main/resources/static/css/changepass.css
@@ -107,12 +107,31 @@ footer {
   position: fixed;
    bottom: 0;
     width: 100%;
+ 	visibility: hidden;
+    /* height: 70px; */
 }
 
+ 
 footer p {
+  margin: 0;
+  padding: 0px 0;
+}
+
+
+
+@media screen and (min-width: 40.5em) {
+  footer {
+    visibility: visible 
+ 	/* height: auto; */
+  }
+  footer p {
   margin: 0;
   padding: 50px 0;
 }
+}
+
+
+
 
 @media screen and (min-width: 768px) {
 
@@ -193,3 +212,6 @@ footer p {
         clear: both;
     }
 }
+
+
+ 

--- a/src/main/resources/static/css/recovery.css
+++ b/src/main/resources/static/css/recovery.css
@@ -109,11 +109,27 @@ footer {
   position: fixed;
    bottom: 0;
     width: 100%;
+ 	visibility: hidden;
+    /* height: 70px; */
 }
 
+ 
 footer p {
   margin: 0;
+  padding: 0px 0;
+}
+
+
+
+@media screen and (min-width: 40.5em) {
+  footer {
+    visibility: visible 
+ 	/* height: auto; */
+  }
+  footer p {
+  margin: 0;
   padding: 50px 0;
+}
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
The footer was blocking the submit button on the recovery and change pages.  Since we need that space at the bottom for validation, I just decided to hide it on phones.