### PR TITLE
Fix wrong font being used

### DIFF
--- a/src/main/resources/static/css/alterpass.css
+++ b/src/main/resources/static/css/alterpass.css
@@ -36,7 +36,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @font-face {
     font-family: din;
-    src: url("../fonts/DIN-Regular.otf");
+    src: url("../fonts/DIN-Regular.ttf");
 }
 @font-face {
     font-family: dincond-bold;

--- a/src/main/resources/static/css/changepass.css
+++ b/src/main/resources/static/css/changepass.css
@@ -14,7 +14,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @font-face {
     font-family: din;
-    src: url("../fonts/DIN-Regular.otf");
+    src: url("../fonts/DIN-Regular.ttf");
 }
 @font-face {
     font-family: dincond-bold;

--- a/src/main/resources/static/css/recovery.css
+++ b/src/main/resources/static/css/recovery.css
@@ -8,7 +8,7 @@ body {
 
 @font-face {
     font-family: din;
-    src: url("../static/fonts/DIN-Regular.otf");
+    src: url("../static/fonts/DIN-Regular.ttf");
 }
 @font-face {
     font-family: dincond-bold;


### PR DESCRIPTION
It was using the .otf version of din, whereas .ttf is what we want.  This fixes the font.  We will also need to make this change on the email.scala.