### PR TITLE
Fix din in e-mailer

### DIFF
--- a/src/main/scala/edu/eckerd/alterpass/email/Emailer.scala
+++ b/src/main/scala/edu/eckerd/alterpass/email/Emailer.scala
@@ -37,7 +37,7 @@ case class Emailer(smtpServer: String, serverHostName: String, user: String, pas
       |<style>
       |@font-face {
       |    font-family: din;
-      |    src: url("http://$serverHostName/static/fonts/DIN-Regular.otf");
+      |    src: url("http://$serverHostName/static/fonts/DIN-Regular.ttf");
       |}
       |@font-face {
       |    font-family: dincond-bold;


### PR DESCRIPTION
Was using .otf instead of .ttf for din.  This should fix the e-mail formatting