### PR TITLE
Remove footer from change and recover pages

### DIFF
--- a/src/main/resources/pages/changepw.html
+++ b/src/main/resources/pages/changepw.html
@@ -94,6 +94,7 @@
 </div>
 <!-- /.container -->
 
+<!-- 
 <footer>
     <div class="container">
         <div class="row">
@@ -103,6 +104,7 @@
         </div>
     </div>
 </footer>
+ -->
 
 
 <!-- JavaScript -->

--- a/src/main/resources/pages/recovery.html
+++ b/src/main/resources/pages/recovery.html
@@ -97,6 +97,7 @@
 
 </div>
 <!-- /.container -->
+<!-- 
 
 <footer>
     <div class="container">
@@ -107,6 +108,8 @@
         </div>
     </div>
 </footer>
+ -->
+
 
 <!-- JavaScript -->
 <!-- <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.js"></script>  -->


### PR DESCRIPTION
Footer was blocking the submit button on some medium-sized, smaller screens.  Let's just get rid of it for now.  We can always make style changes later.