### PR TITLE
UserName check

### DIFF
--- a/src/main/scala/edu/eckerd/alterpass/http/ChangePassword.scala
+++ b/src/main/scala/edu/eckerd/alterpass/http/ChangePassword.scala
@@ -17,10 +17,11 @@ object ChangePassword {
 
   def impl[F[_]](implicit F: Effect[F], L: Ldap[F], A: AgingFile[F], G: GoogleAPI[F]): ChangePassword[F] = new ChangePassword[F]{
     def changePassword(username: String, oldPass: String, newPass: String): F[Unit] = {
-      val ldapUserName = username.replaceAll("@eckerd.edu", "")
-      val googleUserName = if (username.endsWith("@eckerd.edu")) username else s"${username}@eckerd.edu"
+      val lowerCaseUsername = username.toLowerCase
+      val ldapUserName = lowerCaseUsername.replaceAll("@eckerd.edu", "")
+      val googleUserName = if (lowerCaseUsername.endsWith("@eckerd.edu")) lowerCaseUsername else s"${lowerCaseUsername}@eckerd.edu"
 
-      Ldap[F].checkBind(username, oldPass).ifM(
+      Ldap[F].checkBind(ldapUserName, oldPass).ifM(
         {
           for {
             _ <- AgingFile[F].writeUsernamePass(ldapUserName, newPass)

--- a/src/main/scala/edu/eckerd/alterpass/http/ChangePassword.scala
+++ b/src/main/scala/edu/eckerd/alterpass/http/ChangePassword.scala
@@ -27,10 +27,10 @@ object ChangePassword {
             _ <- AgingFile[F].writeUsernamePass(ldapUserName, newPass)
             _ <- Ldap[F].setUserPassword(ldapUserName, newPass)
             _ <- GoogleAPI[F].changePassword(googleUserName, newPass)
-            out <- Sync[F].delay(logger.info(s"Change Password Reset Completed for User: $username"))
+            out <- Sync[F].delay(logger.info(s"Change Password Reset Completed for User: $ldapUserName"))
           } yield out
         },
-        Sync[F].delay(logger.info(s"Failed Change Password Attempt - Invalid Old Password for $username")) *>
+        Sync[F].delay(logger.info(s"Failed Change Password Attempt - Invalid Old Password for $ldapUserName")) *>
         Sync[F].raiseError[Unit](Ldap.BindFailure)
       )
     }

--- a/src/main/scala/edu/eckerd/alterpass/http/ForgotPassword.scala
+++ b/src/main/scala/edu/eckerd/alterpass/http/ForgotPassword.scala
@@ -31,30 +31,35 @@ object ForgotPassword {
     E: EmailService[F]
   ): ForgotPassword[F] = new ForgotPassword[F] {
 
-    override def initiatePasswordReset(username: String): F[ForgotPasswordReturn] = for {
-      now <- Sync[F].delay(Instant.now().getEpochSecond)
-      _ <- SqlLiteDB[F].rateLimitCheck(username, now)
-      _ <- SqlLiteDB[F].removeOlder(now)
-      personalEmails <-OracleDB[F].getPersonalEmails(username)
-      random <- Sync[F].delay(randomAlphaNumeric(40))
-      _ <- EmailService[F].sendNotificationEmail(personalEmails.toList.map(_.emailAddress), random)
-      _ <- SqlLiteDB[F].writeConnection(username, personalEmails.head.emailCode, random, now)
-      concealedAddresses = personalEmails.toList.map(_.emailAddress).map(concealEmail)
-      _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Initiated For User: ${username}"))
-    } yield ForgotPasswordReturn(concealedAddresses)
+    override def initiatePasswordReset(username: String): F[ForgotPasswordReturn] = {
+      val lowerCaseUsername = username.toLowerCase
+      val ldapUserName = lowerCaseUsername.replaceAll("@eckerd.edu", "")
+      val googleUserName = if (lowerCaseUsername.endsWith("@eckerd.edu")) lowerCaseUsername else s"${lowerCaseUsername}@eckerd.edu"
+      for {
+        now <- Sync[F].delay(Instant.now().getEpochSecond)
+        _ <- SqlLiteDB[F].rateLimitCheck(ldapUserName, now)
+        _ <- SqlLiteDB[F].removeOlder(now)
+        personalEmails <-OracleDB[F].getPersonalEmails(ldapUserName)
+        random <- Sync[F].delay(randomAlphaNumeric(40))
+        _ <- EmailService[F].sendNotificationEmail(personalEmails.toList.map(_.emailAddress), random)
+        _ <- SqlLiteDB[F].writeConnection(ldapUserName, personalEmails.head.emailCode, random, now)
+        concealedAddresses = personalEmails.toList.map(_.emailAddress).map(concealEmail)
+        _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Initiated For User: ${username}"))
+      } yield ForgotPasswordReturn(concealedAddresses)
+    }
 
     override def resetPassword(userName: String, newPass: String, extension: String): F[Unit] = {
-      val ldapUserName = userName.replaceAll("@eckerd.edu", "")
-      val googleUserName = if (userName.endsWith("@eckerd.edu")) userName else s"${userName}@eckerd.edu"
-
+      val lowerCaseUsername = userName.toLowerCase
+      val ldapUserName = lowerCaseUsername.replaceAll("@eckerd.edu", "")
+      val googleUserName = if (lowerCaseUsername.endsWith("@eckerd.edu")) lowerCaseUsername else s"${lowerCaseUsername}@eckerd.edu"
       for {
         now <- Sync[F].delay(Instant.now().getEpochSecond) 
         _ <- SqlLiteDB[F].removeOlder(now)
-        user <- SqlLiteDB[F].recoveryLink(userName, extension, now)
+        user <- SqlLiteDB[F].recoveryLink(ldapUserName, extension, now)
         _ <- if (user.emailCode != EmailCode.ECA) Ldap[F].setUserPassword(ldapUserName, newPass) else ().pure[F]
         _ <- if (user.emailCode != EmailCode.ECA) AgingFile[F].writeUsernamePass(ldapUserName, newPass) else ().pure[F]
         _ <- GoogleAPI[F].changePassword(googleUserName, newPass)
-        out <- SqlLiteDB[F].removeRecoveryLink(userName, extension).void
+        out <- SqlLiteDB[F].removeRecoveryLink(ldapUserName, extension).void
         _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Completed for User: ${userName}"))
       } yield out
     }

--- a/src/main/scala/edu/eckerd/alterpass/http/ForgotPassword.scala
+++ b/src/main/scala/edu/eckerd/alterpass/http/ForgotPassword.scala
@@ -44,7 +44,7 @@ object ForgotPassword {
         _ <- EmailService[F].sendNotificationEmail(personalEmails.toList.map(_.emailAddress), random)
         _ <- SqlLiteDB[F].writeConnection(ldapUserName, personalEmails.head.emailCode, random, now)
         concealedAddresses = personalEmails.toList.map(_.emailAddress).map(concealEmail)
-        _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Initiated For User: ${username}"))
+        _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Initiated For User: ${ldapUserName}"))
       } yield ForgotPasswordReturn(concealedAddresses)
     }
 
@@ -60,7 +60,7 @@ object ForgotPassword {
         _ <- if (user.emailCode != EmailCode.ECA) AgingFile[F].writeUsernamePass(ldapUserName, newPass) else ().pure[F]
         _ <- GoogleAPI[F].changePassword(googleUserName, newPass)
         out <- SqlLiteDB[F].removeRecoveryLink(ldapUserName, extension).void
-        _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Completed for User: ${userName}"))
+        _ <- Sync[F].delay(logger.info(s"Forgot Password Reset Completed for User: ${ldapUserName}"))
       } yield out
     }
 


### PR DESCRIPTION
Always Lowercases inputs
Use Ldap Username Everywhere for consistency of naming semantics, rather than the raw input username.